### PR TITLE
PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # Config file for automatic testing at travis-ci.org
 sudo: false
 language: python
-arch: amd64
+arch: 
+- amd64
+- ppc64le
       
       
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # Config file for automatic testing at travis-ci.org
 sudo: false
 language: python
-arch: 
-      - ppc64le
-      - amd64
+arch: amd64
+      
+      
 matrix:
     include:
       - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 # Config file for automatic testing at travis-ci.org
 sudo: false
 language: python
-arch: 
-- amd64
-- ppc64le
+arch: ppc64le
       
       
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # Config file for automatic testing at travis-ci.org
-arch: ppc64le
+arch: 
+     - ppc64le
+     - amd64
 sudo: false
 language: python
 
@@ -15,9 +17,7 @@ matrix:
         env: TOX_ENV=py36
       - python: 3.7
         env: TOX_ENV=py37
-      - python: pypy
-        env: TOX_ENV=pypy
-
+      
 script: tox -e $TOX_ENV
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # Config file for automatic testing at travis-ci.org
 sudo: false
 language: python
-arch: ppc64le
+arch: 
+      - ppc64le
+      - amd64
 matrix:
     include:
       - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Config file for automatic testing at travis-ci.org
-
+arch: ppc64le
 sudo: false
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ matrix:
         env: TOX_ENV=py36
       - python: 3.7
         env: TOX_ENV=py37
-      
-script: tox -e $TOX_ENV
+        
+        script: tox -e $TOX_ENV
 
 install:
     - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 # Config file for automatic testing at travis-ci.org
-arch: 
-     - ppc64le
-     - amd64
 sudo: false
 language: python
-
+arch: ppc64le
 matrix:
     include:
       - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       - python: 3.7
         env: TOX_ENV=py37
         
-        script: tox -e $TOX_ENV
+script: tox -e $TOX_ENV
 
 install:
     - pip install tox


### PR DESCRIPTION
Adding power support ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
The Python Versions=pypy are not available for download and hence excluded from the travis.yml & the build is enabled for other versions of python.
Build is enabled for both arch: ppc64le/amd64.