### PR TITLE
Add type hints (stub files) and py.typed marker

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,9 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 
+include binaryornot/py.typed
+recursive-include binaryornot *.pyi
+
 recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/binaryornot/check.pyi
+++ b/binaryornot/check.pyi
@@ -1,0 +1,3 @@
+from os import PathLike
+
+def is_binary(filename: str | bytes | PathLike) -> bool: ...


### PR DESCRIPTION
Using stub files instead of inline annotations to maintain Python 2 compatibility.

Fixes #626.