### PR TITLE
tox.ini: Don't use 'setup.py test'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 envlist = py27, py33, py34, py35, py36, pypy
 
 [testenv]
-commands = python setup.py test
+commands = python -m unittest discover {posargs}
 deps = hypothesis


### PR DESCRIPTION
setup.py test is deprecated in setuptools 74+.
Since the tests are written using unittest, call
it to discover the tests directly.

Also, add a '{posargs}' argument to the command
for running tests (allows passing arguments to
the command from the tox command line, i.e.
`tox -e py36 -- -v` => `python -m unittest discover -v`